### PR TITLE
Add a preload script to fetch demo images

### DIFF
--- a/knative-kubecon/README.md
+++ b/knative-kubecon/README.md
@@ -16,11 +16,12 @@ Knative's Eventing capabilities.
 
 Before we get started, let's setup an environment. This setup guide assumes the usage of `minishift` and the
 setup scripts are tailored to facilitate that. To setup a fresh minishift cluster with OLM, Istio and all parts
-we need from Knative installed, run the following script:
+we need from Knative installed, run the following scripts:
 
 ```bash
 git clone git@github.com:openshift-cloud-functions/knative-operators.git
 ./knative-operators/etc/scripts/install.sh
+./scripts/preload.sh
 ```
 
 > This script is destructive towards the 'knative' profile in minishift.

--- a/knative-kubecon/scripts/preload.sh
+++ b/knative-kubecon/scripts/preload.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+set -x
+
+eval "$(minishift docker-env)"
+docker image pull centos/go-toolset-7-centos7:latest
+docker image pull vdemeester/kobw-builder:0.1.1
+for img in $(oc get image.caching.internal.knative.dev -ojsonpath='{range .items[*]}{.spec.image}{"\n"}{end}' --all-namespaces)
+do
+    docker pull $img
+done


### PR DESCRIPTION
- the golang image used for demos
- the kobw-builder image used for demos
- any knative to-be-cached images

---

This follows https://github.com/openshift-cloud-functions/knative-operators/pull/11#issuecomment-443814400 and slack discussion

/cc @matzew @markusthoemmes @jcrossley3 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>