### PR TITLE
Clone demo repo right away

### DIFF
--- a/knative-kubecon/README.md
+++ b/knative-kubecon/README.md
@@ -19,9 +19,9 @@ setup scripts are tailored to facilitate that. To setup a fresh minishift cluste
 we need from Knative installed, run the following scripts:
 
 ```bash
-git clone git@github.com:openshift-cloud-functions/demo.git
-cd demo
-git clone git@github.com:openshift-cloud-functions/knative-operators.git
+git clone https://github.com/openshift-cloud-functions/demos.git
+cd demos/knative-kubecon
+git clone https://github.com/openshift-cloud-functions/knative-operators.git
 ./knative-operators/etc/scripts/install.sh
 ./scripts/preload.sh
 ```

--- a/knative-kubecon/README.md
+++ b/knative-kubecon/README.md
@@ -19,6 +19,8 @@ setup scripts are tailored to facilitate that. To setup a fresh minishift cluste
 we need from Knative installed, run the following scripts:
 
 ```bash
+git clone git@github.com:openshift-cloud-functions/demo.git
+cd demo
 git clone git@github.com:openshift-cloud-functions/knative-operators.git
 ./knative-operators/etc/scripts/install.sh
 ./scripts/preload.sh
@@ -32,12 +34,6 @@ After this script exits without any errors, your cluster will be setup and ready
 ```bash
 eval $(minishift oc-env)
 oc project myproject
-```
-
-Now you need to clone _this_ repository in order perform the commandline steps below:
-
-```bash
-git clone git@github.com:openshift-cloud-functions/demo.git
 ```
 
 There we are, let's get crackin'.


### PR DESCRIPTION
The first set of commands assumes you have the demo repo cloned locally and then clone knative-operators repo inside there. But the instructions didn't actually ask you to clone the demo repo until later.