### PR TITLE
Quicker scale-down for demo purposes

### DIFF
--- a/knative-kubecon/serving/010-service.yaml
+++ b/knative-kubecon/serving/010-service.yaml
@@ -26,6 +26,7 @@ spec:
             alpha.image.policy.openshift.io/resolve-names: "*"
         spec:
           containerConcurrency: 1
+          timeoutSeconds: 60
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest

--- a/knative-kubecon/serving/011-service-update.yaml
+++ b/knative-kubecon/serving/011-service-update.yaml
@@ -28,6 +28,7 @@ spec:
             alpha.image.policy.openshift.io/resolve-names: "*"
         spec:
           containerConcurrency: 1
+          timeoutSeconds: 60
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest

--- a/knative-kubecon/serving/012-service-traffic.yaml
+++ b/knative-kubecon/serving/012-service-traffic.yaml
@@ -28,6 +28,7 @@ spec:
             alpha.image.policy.openshift.io/resolve-names: "*"
         spec:
           containerConcurrency: 1
+          timeoutSeconds: 60
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest

--- a/knative-kubecon/serving/013-service-final.yaml
+++ b/knative-kubecon/serving/013-service-final.yaml
@@ -28,6 +28,7 @@ spec:
             alpha.image.policy.openshift.io/resolve-names: "*"
         spec:
           containerConcurrency: 1
+          timeoutSeconds: 60
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest


### PR DESCRIPTION
* Scale down revision in 60s instead of the default 5m

This is to address https://jira.coreos.com/browse/SRVKS-16