### PR TITLE
Request far less CPU for the dumpy ksvc pods

### DIFF
--- a/knative-kubecon/serving/010-service.yaml
+++ b/knative-kubecon/serving/010-service.yaml
@@ -30,3 +30,6 @@ spec:
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest
+            resources:
+              requests:
+                cpu: 50m

--- a/knative-kubecon/serving/011-service-update.yaml
+++ b/knative-kubecon/serving/011-service-update.yaml
@@ -32,3 +32,6 @@ spec:
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest
+            resources:
+              requests:
+                cpu: 50m

--- a/knative-kubecon/serving/012-service-traffic.yaml
+++ b/knative-kubecon/serving/012-service-traffic.yaml
@@ -32,3 +32,6 @@ spec:
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest
+            resources:
+              requests:
+                cpu: 50m

--- a/knative-kubecon/serving/013-service-final.yaml
+++ b/knative-kubecon/serving/013-service-final.yaml
@@ -32,3 +32,6 @@ spec:
           container:
             imagePullPolicy: Always
             image: image-registry.openshift-image-registry.svc:5000/myproject/dumpy:latest
+            resources:
+              requests:
+                cpu: 50m


### PR DESCRIPTION
This prevents smaller OpenShift 4 clusters from running out of CPU
just to run this demo. The Knative default is 400m and this cuts that
down to 1/8th, or 50m. These pods don't consume any real CPU anyway.